### PR TITLE
Remove build scripts for arcadeum-server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+matrix:
+  include:
+
+#
+# SkyWeaver API
+#
+    - language: go
+      go:
+        - "1.10.x"
+      sudo: required
+      before_script:
+        - docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+        - export GIT_BRANCH=$TRAVIS_BRANCH
+      script:
+        - (cd server && make docker-push)
+
+notifications:
+  email: false

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -21,6 +21,3 @@ RUN apk add --no-cache --update ca-certificates tzdata
 COPY --from=builder /go/src/github.com/horizon-games/arcadeum/server/bin/* /usr/bin/
 
 EXPOSE 8000
-
-# TODO: make this path configurable or fix playbook
-CMD ["/usr/bin/arcadeum-server", "-config=/data/etc/arcadeum-server.dev.conf"]

--- a/server/Makefile
+++ b/server/Makefile
@@ -2,6 +2,12 @@ DEPLOY_TARGET ?= dev
 SHELL=bash -o pipefail
 TEST_FLAGS ?=
 
+ARCADEUM_SERVER_IMAGE		?= arcadeum/server
+
+GIT_BRANCH				?= $(shell git rev-parse --abbrev-ref HEAD)
+GIT_SHORTHASH			= $(shell git rev-parse --short=8 HEAD)
+DOCKER_TAG				= $(shell echo "${GIT_SHORTHASH}_${GIT_BRANCH}")
+
 all:
 	@echo "***************************************************************************"
 	@echo "**                      DGame Server Build Tool                          **"
@@ -135,3 +141,10 @@ dep-status: $(GOPATH)/bin/dep
 
 deploy:
 	ansible-playbook -i ../../SkyWeaver/config/ansible.hosts -v playbook.yml -e "host=$(DEPLOY_TARGET)"
+
+docker-image:
+	docker build -t $(ARCADEUM_SERVER_IMAGE) -f ./Dockerfile .
+
+docker-push: docker-image
+	docker tag $(ARCADEUM_SERVER_IMAGE) $(ARCADEUM_SERVER_IMAGE):$(DOCKER_TAG) && \
+	docker push $(ARCADEUM_SERVER_IMAGE):$(DOCKER_TAG)

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,12 +1,12 @@
-DEPLOY_TARGET ?= dev
-SHELL=bash -o pipefail
-TEST_FLAGS ?=
+SHELL                   = bash -o pipefail
+DEPLOY_TARGET           ?= dev
+TEST_FLAGS              ?=
 
-ARCADEUM_SERVER_IMAGE		?= arcadeum/server
+ARCADEUM_SERVER_IMAGE   ?= arcadeum/server
 
-GIT_BRANCH				?= $(shell git rev-parse --abbrev-ref HEAD)
-GIT_SHORTHASH			= $(shell git rev-parse --short=8 HEAD)
-DOCKER_TAG				= $(shell echo "${GIT_SHORTHASH}_${GIT_BRANCH}")
+GIT_BRANCH              ?= $(shell git rev-parse --abbrev-ref HEAD)
+GIT_SHORTHASH           = $(shell git rev-parse --short=8 HEAD)
+DOCKER_TAG              = $(shell echo "${GIT_SHORTHASH}_${GIT_BRANCH}")
 
 all:
 	@echo "***************************************************************************"


### PR DESCRIPTION
Deployment script is no longer required. We'll use our CI bot to push to docker hub.