### PR TITLE
ethereum: add dev network

### DIFF
--- a/ethereum/package.json
+++ b/ethereum/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "build": "rm -rf ./build && truffle compile",
     "migrate": "truffle migrate --network local --verbose-rpc",
+    "dev:migrate": "truffle migrate --network dev --verbose-rpc",
     "staging:migrate": "truffle migrate --network rinkeby",
     "prepare-abi": "echo TODO",
     "ganache": "ganache-cli -d -h 0.0.0.0 -e 1000000000 -g 1 -l 4000000000000000 --allowUnlimitedContractSize",

--- a/ethereum/truffle.js
+++ b/ethereum/truffle.js
@@ -4,6 +4,14 @@ module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
   networks: {
+    dev: {
+      host: "172.31.42.208",
+      port: 8545,
+      network_id: "*",
+      gasPrice: 1,
+      gasLimit: 4000000000000000,
+      gas: 9000000000
+    },
     local: {
       host: "127.0.0.1",
       port: 8545,


### PR DESCRIPTION
This is a temporary solution, we need to find a proper way to deploy migrations to a dev/stg/prod node without relying on truffle or a local config file. 